### PR TITLE
CSS効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け効け

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,9 @@
 import { FC } from "react";
+import styles from "../styles/Layout.module.scss";
 
 const Footer: FC<{}> = () => {
     return (
-        <footer style={{ textAlign: "center" }}>
+        <footer className={styles.center}>
             <p>
                 <small>(C)2021 淵野アタリ</small>
             </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,13 @@
 import { FC } from "react";
 import Link from "next/link";
 import ExternalLink from "./ExternalLink";
+import styles from "../styles/style.module.scss";
 
 const Header: FC<{}> = () => {
     return (
         <header>
-            <h1 style={{ textAlign: "center" }}>捻れたバベル</h1>
-            <nav style={{ textAlign: "center" }}>
+            <h1 className={styles.center}>捻れたバベル</h1>
+            <nav className={styles.center}>
                 <Link href="/">
                     <a>TOP</a>
                 </Link>{" "}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import Link from "next/link";
 import ExternalLink from "./ExternalLink";
-import styles from "../styles/style.module.scss";
+import styles from "../styles/Layout.module.scss";
 
 const Header: FC<{}> = () => {
     return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,20 @@
 import { FC } from "react";
 import { AppProps } from "next/app";
 import "../styles/app.scss";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import styles from "../styles/Layout.module.scss";
 
 const App: FC<AppProps> = ({ Component, pageProps }) => {
-    return <Component {...pageProps} />;
+    return (
+        <>
+            <Header />
+            <main className={styles.main}>
+                <Component {...pageProps} />
+            </main>
+            <Footer />
+        </>
+    );
 };
 
 export default App;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,4 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
-import Header from "../components/Header";
-import Footer from "../components/Footer";
 
 class MyDocument extends Document {
     render(): JSX.Element {
@@ -8,11 +6,7 @@ class MyDocument extends Document {
             <Html lang="ja">
                 <Head />
                 <body>
-                    <Header />
-                    <main style={{ maxWidth: "1080px", margin: "0 auto" }}>
-                        <Main />
-                    </main>
-                    <Footer />
+                    <Main />
                     <NextScript />
                 </body>
             </Html>

--- a/src/styles/Layout.module.scss
+++ b/src/styles/Layout.module.scss
@@ -1,0 +1,8 @@
+.main {
+    max-width: 1080px;
+    margin: 0 auto;
+}
+
+.center {
+    text-align: center;
+}

--- a/src/styles/style.module.scss
+++ b/src/styles/style.module.scss
@@ -1,0 +1,3 @@
+.center {
+    text-align: center;
+}

--- a/src/styles/style.module.scss
+++ b/src/styles/style.module.scss
@@ -1,3 +1,0 @@
-.center {
-    text-align: center;
-}


### PR DESCRIPTION
ヘッダーが CSS Modules 使用(`text-align: center`をかけているのに左寄せになる)

NextJSの公式ドキュメント
https://nextjs.org/docs/basic-features/built-in-css-support#adding-component-level-css